### PR TITLE
Details in gpx extensions

### DIFF
--- a/core/src/main/java/com/graphhopper/util/gpx/GpxFromInstructions.java
+++ b/core/src/main/java/com/graphhopper/util/gpx/GpxFromInstructions.java
@@ -19,14 +19,13 @@
 package com.graphhopper.util.gpx;
 
 import com.graphhopper.util.*;
+import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.shapes.GHPoint3D;
 
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Locale;
+import java.util.*;
 
 // todo: the code here does not really belong into core, but we moved it here for now so its available from
 // map-matching resource (it cannot be in the api module, because it uses AngleCalc). Probably we should separate the
@@ -80,6 +79,10 @@ public class GpxFromInstructions {
     }
 
     public static String createGPX(InstructionList instructions, String trackName, long startTimeMillis, boolean includeElevation, boolean withRoute, boolean withTrack, boolean withWayPoints, String version, Translation tr) {
+        return createGPX(instructions, trackName, startTimeMillis, includeElevation, withRoute, withTrack, withWayPoints, version, tr, Collections.emptyMap());
+    }
+
+    public static String createGPX(InstructionList instructions, String trackName, long startTimeMillis, boolean includeElevation, boolean withRoute, boolean withTrack, boolean withWayPoints, String version, Translation tr, Map<String, List<PathDetail>> pathDetails) {
         DateFormat formatter = Helper.createFormatter();
 
         DecimalFormat decimalFormat = new DecimalFormat("#", DecimalFormatSymbols.getInstance(Locale.ROOT));
@@ -115,13 +118,15 @@ public class GpxFromInstructions {
             if (withRoute) {
                 gpxOutput.append("\n<rte>");
                 Instruction nextInstr = null;
+                int point = 0;
                 for (Instruction currInstr : instructions) {
                     if (null != nextInstr)
-                        createRteptBlock(gpxOutput, nextInstr, currInstr, decimalFormat, tr);
+                        createRteptBlock(gpxOutput, nextInstr, currInstr, decimalFormat, tr, getPathDetailsForRtept(pathDetails, point));
 
                     nextInstr = currInstr;
+                    point++;
                 }
-                createRteptBlock(gpxOutput, nextInstr, null, decimalFormat, tr);
+                createRteptBlock(gpxOutput, nextInstr, null, decimalFormat, tr, getPathDetailsForRtept(pathDetails, point));
                 gpxOutput.append("\n</rte>");
             }
         }
@@ -147,7 +152,7 @@ public class GpxFromInstructions {
         return gpxOutput.toString();
     }
 
-    private static void createRteptBlock(StringBuilder output, Instruction instruction, Instruction nextI, DecimalFormat decimalFormat, Translation tr) {
+    private static void createRteptBlock(StringBuilder output, Instruction instruction, Instruction nextI, DecimalFormat decimalFormat, Translation tr, Map<String, String> details) {
         output.append("\n<rtept lat=\"").append(decimalFormat.format(instruction.getPoints().getLatitude(0))).
                 append("\" lon=\"").append(decimalFormat.format(instruction.getPoints().getLongitude(0))).append("\">");
 
@@ -173,6 +178,9 @@ public class GpxFromInstructions {
         }
 
         output.append("<gh:sign>").append(instruction.getSign()).append("</gh:sign>");
+
+        output.append(gpxExtensionsForDetails(details));
+
         output.append("</extensions>");
         output.append("</rtept>");
     }
@@ -211,5 +219,37 @@ public class GpxFromInstructions {
         double lat = instruction.getPoints().getLatitude(0);
         double lon = instruction.getPoints().getLongitude(0);
         return AC.calcAzimuth(lat, lon, nextLat, nextLon);
+    }
+
+    private static Map<String, String> getPathDetailsForRtept(Map<String, List<PathDetail>> pathDetails, int rtept) {
+        Map<String, String> retVal = new HashMap<>();
+        for (Map.Entry<String, List<PathDetail>> detail :  pathDetails.entrySet()) {
+            PathDetail pathDetail = getPathDetailsForRtept(detail, rtept);
+            retVal.put(detail.getKey(), pathDetail != null ? pathDetail.getValue().toString() : "");
+        }
+        return retVal;
+    }
+
+    private static PathDetail getPathDetailsForRtept(Map.Entry<String, List<PathDetail>> pathDetails, int rtept) {
+        for (PathDetail pathDetail : pathDetails.getValue()) {
+            if(isPointInDetailsRange(rtept, pathDetail)) {
+                return pathDetail;
+            }
+        }
+        return null;
+    }
+
+    private static boolean isPointInDetailsRange(int rtept, PathDetail pathDetail) {
+        return rtept > pathDetail.getFirst() && rtept <= pathDetail.getLast();
+    }
+
+    private static String gpxExtensionsForDetails(Map<String, String> details) {
+        StringBuilder output = new StringBuilder();
+        details.forEach((key, value) -> output.append(gpxExtensionForDetail(key, value)));
+        return output.toString();
+    }
+
+    private static String gpxExtensionForDetail(String key, String value) {
+        return "<gh:" + key + ">" + value + "</gh:" + key + ">";
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/RouteResource.java
@@ -25,6 +25,7 @@ import com.graphhopper.http.GHPointParam;
 import com.graphhopper.http.WebHelper;
 import com.graphhopper.routing.ProfileResolver;
 import com.graphhopper.util.*;
+import com.graphhopper.util.details.PathDetail;
 import com.graphhopper.util.gpx.GpxFromInstructions;
 import com.graphhopper.util.shapes.GHPoint;
 import io.dropwizard.jersey.params.AbstractParam;
@@ -240,7 +241,8 @@ public class RouteResource {
 
         long time = timeString != null ? Long.parseLong(timeString) : System.currentTimeMillis();
         InstructionList instructions = ghRsp.getBest().getInstructions();
-        return Response.ok(GpxFromInstructions.createGPX(instructions, trackName, time, enableElevation, withRoute, withTrack, withWayPoints, version, instructions.getTr()), "application/gpx+xml").
+        Map<String, List<PathDetail>> pathDetails = ghRsp.getBest().getPathDetails();
+        return Response.ok(GpxFromInstructions.createGPX(instructions, trackName, time, enableElevation, withRoute, withTrack, withWayPoints, version, instructions.getTr(), pathDetails), "application/gpx+xml").
                 header("Content-Disposition", "attachment;filename=" + "GraphHopper.gpx");
     }
 


### PR DESCRIPTION
The routing API generally allows to output details such as street_name, surfe etc. However, if the output is `type=gpx` then those details were not returned up until now. This PR adds this information to the extensions section of the returned GPX.
This information actually applies to the way segment between two points but since that's not possible in GPX format, it is always added to the point at the end of the segment. Obviously the first point won't have details, the second point contains the details of the first segment, the third point those of the second segment etc.

The details show up in the extensions section of the GPX file:

![image](https://user-images.githubusercontent.com/9936225/94192216-ecdea400-feae-11ea-9405-6b63bebe126e.png)


See also: https://docs.graphhopper.com/#tag/Routing-API